### PR TITLE
Arbitrary Custom Fields On A Subscriber

### DIFF
--- a/app/Http/Controllers/ListSubscribersController.php
+++ b/app/Http/Controllers/ListSubscribersController.php
@@ -141,7 +141,8 @@ class ListSubscribersController extends Controller
      */
     public function update(SubscriberRequest $request, $listId, $id)
     {
-        $input = $request->only($this->validFields) + ['meta' => $this->processMetaFields($request->get('meta_fields'))];
+        $input = $request->only($this->validFields)
+            + ['meta' => $this->processMetaFields($request->get('meta_fields'))];
 
         $subscriber = $this->subscriberRepository->update($id, $input);
         $this->subscriberRepository->syncTags($subscriber, $request->get('tags', []));

--- a/app/Http/Controllers/ListSubscribersController.php
+++ b/app/Http/Controllers/ListSubscribersController.php
@@ -26,6 +26,14 @@ class ListSubscribersController extends Controller
      */
     protected $tagRepository;
 
+    /**
+     * @var array
+     */
+    protected $validFields = [
+        'email',
+        'first_name',
+        'last_name',
+    ];
 
     /**
      * SubscribersController constructor.
@@ -81,7 +89,11 @@ class ListSubscribersController extends Controller
      */
     public function store(SubscriberRequest $request, $listId)
     {
-        $subscriber = $this->subscriberRepository->store($request->all() + ['subscriber_list_id' => $listId]);
+        $input = $request->only($this->validFields)
+            + ['meta' => $this->processMetaFields($request->get('meta_fields'))]
+            + ['subscriber_list_id' => $listId];
+
+        $subscriber = $this->subscriberRepository->store($input);
         $this->subscriberRepository->syncTags($subscriber, $request->get('tags', []));
 
         return redirect()->route('lists.subscribers.index', $listId);
@@ -129,7 +141,9 @@ class ListSubscribersController extends Controller
      */
     public function update(SubscriberRequest $request, $listId, $id)
     {
-        $subscriber = $this->subscriberRepository->update($id, $request->all());
+        $input = $request->only($this->validFields) + ['meta' => $this->processMetaFields($request->get('meta_fields'))];
+
+        $subscriber = $this->subscriberRepository->update($id, $input);
         $this->subscriberRepository->syncTags($subscriber, $request->get('tags', []));
 
         return redirect()->route('lists.subscribers.index', $listId);
@@ -144,5 +158,28 @@ class ListSubscribersController extends Controller
     public function destroy($id)
     {
         app()->abort(404, 'Not implemented');
+    }
+
+    /**
+     * Process the meta fields to be passed to the repository
+     *
+     * @param array $metaFields
+     *
+     * @return string
+     */
+    protected function processMetaFields(array $metaFields = null)
+    {
+        if ( ! $metaFields)
+        {
+            return null;
+        }
+
+        return json_encode(array_map(function($meta) {
+            return [
+                'name' => snake_case($meta['label']),
+                'label' => $meta['label'],
+                'value' => $meta['value']
+            ];
+        }, $metaFields));
     }
 }

--- a/app/Models/Subscriber.php
+++ b/app/Models/Subscriber.php
@@ -12,6 +12,7 @@ class Subscriber extends BaseModel
         'first_name',
         'last_name',
         'unsubscribed_at',
+        'meta'
     ];
 
     public function subscriberList()

--- a/app/Services/NewsletterContentService.php
+++ b/app/Services/NewsletterContentService.php
@@ -174,7 +174,7 @@ class NewsletterContentService implements NewsletterContentServiceInterface
             'email' => $subscriber->email,
             'first_name' => $subscriber->first_name,
             'last_name' => $subscriber->last_name,
-        ];
+        ] + $this->processCustomFields($subscriber);
 
         // regex doesn't seem to work here - I think it
         // may be due to all the tags and inverted commas in html?
@@ -191,11 +191,36 @@ class NewsletterContentService implements NewsletterContentServiceInterface
                 '{{' . $key . '}}',
                 '{{ ' . $key . ' }}',
             ];
+
             $content = str_ireplace($search, $value, $content);
         }
 
         // merge subscriber into newsletter url tracking
         return str_ireplace($this->subscriberIdReplacementTag, $subscriber->id, $content);
+    }
+
+    /**
+     * Process the subscriber's custom fields into usable tags
+     *
+     * @param Subscriber $subscriber
+     *
+     * @return array
+     */
+    protected function processCustomFields(Subscriber $subscriber)
+    {
+        $fields = json_decode($subscriber->meta, true);
+
+        $tags = [];
+
+        if ( ! empty($fields))
+        {
+            foreach ($fields as $field)
+            {
+                $tags[$field['name']] = $field['value'];
+            }
+        }
+
+        return $tags;
     }
 
     /**

--- a/resources/views/lists/subscribers/create.blade.php
+++ b/resources/views/lists/subscribers/create.blade.php
@@ -10,4 +10,5 @@
 
     @include('lists.subscribers.partials.form')
 
+    {!! Form::close() !!}
 @stop

--- a/resources/views/lists/subscribers/edit.blade.php
+++ b/resources/views/lists/subscribers/edit.blade.php
@@ -10,4 +10,6 @@
 
     @include('lists.subscribers.partials.form')
 
+    {!! Form::close() !!}
+
 @stop

--- a/resources/views/lists/subscribers/partials/form.blade.php
+++ b/resources/views/lists/subscribers/partials/form.blade.php
@@ -11,6 +11,17 @@
     </div>
 @endforeach
 
-{!! Form::submitButton('Save') !!}
+<div class="well">
+    <h4>Custom Fields</h4>
 
-{!! Form::close() !!}
+    @if ( ! empty($subscriber->meta))
+        @foreach (json_decode($subscriber->meta) as $id => $metaField)
+            @include('lists.subscribers.partials.meta_field', compact('$metaField'))
+        @endforeach
+    @endif
+
+    <button class="btn btn-default btn-sm">Add Custom Field</button>
+</div>
+
+
+{!! Form::submitButton('Save') !!}

--- a/resources/views/lists/subscribers/partials/meta_field.blade.php
+++ b/resources/views/lists/subscribers/partials/meta_field.blade.php
@@ -1,0 +1,4 @@
+{!! Form::text("meta_fields[{$id}][label]", $metaField->label, ['class' => 'form-control']) !!}
+{!! Form::text("meta_fields[{$id}][value]", $metaField->value, ['class' => 'form-control']) !!}
+
+<hr>


### PR DESCRIPTION
WIP

Currently implements the saving/updating logic in the backend that allows a subscriber to have arbitrary fields assigned to it.

TODO:
- UI for adding/removing fields (javascript)
- Filling templates with custom field data when sending newsletters